### PR TITLE
Updated compareObject in DcemUtils & minor changes

### DIFF
--- a/AppSecureModule/src/com/doubleclue/dcem/as/entities/CloudSafeEntity.java
+++ b/AppSecureModule/src/com/doubleclue/dcem/as/entities/CloudSafeEntity.java
@@ -2,6 +2,7 @@ package com.doubleclue.dcem.as.entities;
 
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 import javax.persistence.Column;
@@ -513,35 +514,35 @@ public class CloudSafeEntity extends EntityInterface implements Cloneable {
 	public void setGroup(DcemGroup group) {
 		this.group = group;
 	}
+	
+	
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((device == null) ? 0 : device.hashCode());
-		result = prime * result + ((deviceName == null) ? 0 : deviceName.hashCode());
-		result = prime * result + ((discardAfter == null) ? 0 : discardAfter.hashCode());
-		result = prime * result + ((group == null) ? 0 : group.hashCode());
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		result = prime * result + (isFolder ? 1231 : 1237);
-		result = prime * result + ((isGcm == null) ? 0 : isGcm.hashCode());
-		result = prime * result + ((lastModified == null) ? 0 : lastModified.hashCode());
-		result = prime * result + ((lastModifiedUser == null) ? 0 : lastModifiedUser.hashCode());
-		result = prime * result + (int) (length ^ (length >>> 32));
-		result = prime * result + ((lengthString == null) ? 0 : lengthString.hashCode());
-		result = prime * result + ((loginId == null) ? 0 : loginId.hashCode());
-		result = prime * result + ((name == null) ? 0 : name.hashCode());
-		result = prime * result + (newEntity ? 1231 : 1237);
-		result = prime * result + ((options == null) ? 0 : options.hashCode());
-		result = prime * result + ((owner == null) ? 0 : owner.hashCode());
-		result = prime * result + ((parent == null) ? 0 : parent.hashCode());
-		result = prime * result + (recycled ? 1231 : 1237);
-		result = prime * result + (restrictDownload ? 1231 : 1237);
-		result = prime * result + Arrays.hashCode(salt);
-		result = prime * result + ((user == null) ? 0 : user.hashCode());
-		result = prime * result + (writeAccess ? 1231 : 1237);
-		return result;
-	}
+//	@Override
+//	public int hashCode() {
+//		final int prime = 31;
+//		int result = 1;
+//		result = prime * result + ((device == null) ? 0 : device.hashCode());
+//		result = prime * result + ((deviceName == null) ? 0 : deviceName.hashCode());
+//		result = prime * result + ((discardAfter == null) ? 0 : discardAfter.hashCode());
+//		result = prime * result + ((group == null) ? 0 : group.hashCode());
+//		result = prime * result + ((id == null) ? 0 : id.hashCode());
+//		result = prime * result + (isFolder ? 1231 : 1237);
+//		result = prime * result + ((isGcm == null) ? 0 : isGcm.hashCode());
+//		result = prime * result + ((lastModified == null) ? 0 : lastModified.hashCode());
+//		result = prime * result + ((lastModifiedUser == null) ? 0 : lastModifiedUser.hashCode());
+//		result = prime * result + (int) (length ^ (length >>> 32));
+//		result = prime * result + ((lengthString == null) ? 0 : lengthString.hashCode());
+//		result = prime * result + ((loginId == null) ? 0 : loginId.hashCode());
+//		result = prime * result + ((name == null) ? 0 : name.hashCode());
+//		result = prime * result + (newEntity ? 1231 : 1237);
+//		result = prime * result + ((options == null) ? 0 : options.hashCode());
+//		result = prime * result + ((owner == null) ? 0 : owner.hashCode());
+//		result = prime * result + (recycled ? 1231 : 1237);
+//		result = prime * result + (restrictDownload ? 1231 : 1237);
+//		result = prime * result + ((user == null) ? 0 : user.hashCode());
+//		result = prime * result + (writeAccess ? 1231 : 1237);
+//		return result;
+//	}
 
 	@Override
 	public boolean equals(Object obj) {
@@ -640,6 +641,23 @@ public class CloudSafeEntity extends EntityInterface implements Cloneable {
 			return false;
 		return true;
 	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id);
+	}
+
+//	@Override
+//	public boolean equals(Object obj) {
+//		if (this == obj)
+//			return true;
+//		if (obj == null)
+//			return false;
+//		if (getClass() != obj.getClass())
+//			return false;
+//		CloudSafeEntity other = (CloudSafeEntity) obj;
+//		return Objects.equals(id, other.id);
+//	}
 
 	public boolean isFile() {
 		return isFolder == false;

--- a/DcemCore/src/com/doubleclue/dcem/core/gui/DcemGui.java
+++ b/DcemCore/src/com/doubleclue/dcem/core/gui/DcemGui.java
@@ -37,5 +37,5 @@ public @interface DcemGui {
 	public boolean masterOnly() default false;
 	public VariableType variableType() default VariableType.UNKNOWN;
 	public boolean restricted() default false;
-	
+	public boolean ignoreCompare() default false;
 }

--- a/DcemCore/src/com/doubleclue/dcem/core/utils/DcemUtils.java
+++ b/DcemCore/src/com/doubleclue/dcem/core/utils/DcemUtils.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.Set;
@@ -74,6 +76,9 @@ import javax.persistence.metamodel.SingularAttribute;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolation;
 
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Equator;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hibernate.exception.ConstraintViolationException;
@@ -733,10 +738,37 @@ public class DcemUtils {
 				if (oldField.isAnnotationPresent(javax.persistence.Version.class)) {
 					continue;
 				}
+				if (oldField.isAnnotationPresent(DcemGui.class)) {
+					if(oldField.getAnnotation(DcemGui.class).ignoreCompare() == true) {
+						continue;
+					}
+				}
 				newField = newObjectClass.getDeclaredField(oldField.getName());
 				newField.setAccessible(true);
 				oldField.setAccessible(true);
-				Class<?> cls = oldField.getType();
+				Class<?> cls = oldField.getType();	
+				
+				if (oldField.isAnnotationPresent(DcemGui.class)) {					
+					if(oldField.getAnnotation(DcemGui.class).variableType() == VariableType.IMAGE) {
+						byte[] oldImage = (((byte[]) oldField.get(oldObject)) != null) ? (byte[]) oldField.get(oldObject) : null;
+						byte[] newImage = (((byte[]) newField.get(newObject)) != null) ? (byte[]) newField.get(newObject) : null;
+						
+						if (Objects.deepEquals(oldImage, newImage) == false) {
+							stringBuilder.append(oldField.getName());
+							stringBuilder.append(": ");
+							stringBuilder.append(Objects.isNull(oldImage) ? "null" : ":IMAGE AVAILABLE:");
+							stringBuilder.append(unicodeRightArrow);
+							stringBuilder.append(Objects.isNull(newImage) ? "null" : (Objects.isNull(oldImage) ? ":IMAGE INSERTED:" : ":IMAGE UPDATED:"));
+							stringBuilder.append(fin);
+						}
+						continue;
+					}
+					
+					if(oldField.getAnnotation(DcemGui.class).variableType() == VariableType.OTHER) {
+						continue;
+					}
+				}
+				
 				if (cls.equals(String.class)) {
 					String oldString = (((String) oldField.get(oldObject)) != null) ? (String) oldField.get(oldObject) : "null";
 					String newString = (((String) newField.get(newObject)) != null) ? (String) newField.get(newObject) : "null";
@@ -746,6 +778,10 @@ public class DcemUtils {
 						DcemGui dcemGui = oldField.getAnnotation(DcemGui.class);
 						if (dcemGui != null && dcemGui.password()) {
 							stringBuilder.append(newString.equals("null") ? newString : ":PASSWORD:");
+						} else if (dcemGui != null && dcemGui.variableType() == VariableType.STRING) {
+							stringBuilder.append(oldString.equals("null") ? oldString : ":LONG TEXT AVAILABLE:");
+							stringBuilder.append(unicodeRightArrow);
+							stringBuilder.append(newString.equals("null") ? newString : (oldString.equals("null") ? ":LONG TEXT INSERTED:" : ":LONG TEXT UPDATED:"));
 						} else {
 							stringBuilder.append(oldString);
 							stringBuilder.append(unicodeRightArrow);
@@ -829,6 +865,74 @@ public class DcemUtils {
 							stringBuilder.append(fin);
 						}
 					}
+				} else if (cls.equals(List.class)) {
+					List<?> oldList = Objects.isNull(oldField.get(oldObject)) == true ? new ArrayList<>() : (List<?>) oldField.get(oldObject);
+					List<?> newList = Objects.isNull(oldField.get(newObject)) == true ? new ArrayList<>() : (List<?>) oldField.get(newObject);
+					if(oldList.size() != 0 && newList.size() != 0) {
+						if(oldList.get(0).getClass().getSuperclass() == EntityInterface.class) {								
+							List<? extends EntityInterface> oldEntityList = (List<? extends EntityInterface>) oldList;
+							List<? extends EntityInterface> newEntityList = (List<? extends EntityInterface>) newList;
+							if(CollectionUtils.isEqualCollection(oldEntityList, newEntityList) == false) {
+								stringBuilder.append(oldField.getName());
+								stringBuilder.append(": ");
+								stringBuilder.append(oldEntityList.size() == 0 ? "null" : ":LIST AVAILABLE:");
+								stringBuilder.append(unicodeRightArrow);
+								stringBuilder.append(newEntityList.size() == 0 ? "null" : (oldEntityList.size() == 0 ? ":LIST INSERTED:" : ":LIST UPDATED:"));
+								stringBuilder.append(fin);
+							}
+						} else {
+							if(CollectionUtils.isEqualCollection(oldList, newList) == false) {
+								stringBuilder.append(oldField.getName());
+								stringBuilder.append(": ");
+								stringBuilder.append(oldList.size() == 0 ? "null" : ":LIST AVAILABLE:");
+								stringBuilder.append(unicodeRightArrow);
+								stringBuilder.append(newList.size() == 0 ? "null" : (oldList.size() == 0 ? ":LIST INSERTED:" : ":LIST UPDATED:"));
+								stringBuilder.append(fin);
+							}
+						}
+					}
+				} else if (cls.getSuperclass() == EntityInterface.class) {
+					EntityInterface oldEntity = Objects.isNull(oldField.get(oldObject)) ? new EntityInterface() {
+														@Override
+														public Number getId() {
+															return null;
+														}
+								
+														@Override
+														public void setId(Number id) { }
+												} : (EntityInterface) oldField.get(oldObject);
+					EntityInterface newEntity = Objects.isNull(oldField.get(newObject)) ? new EntityInterface() {
+														@Override
+														public Number getId() {
+															return null;
+														}
+								
+														@Override
+														public void setId(Number id) { }
+												} : (EntityInterface) oldField.get(newObject);
+					if(oldEntity.getId() != null || newEntity.getId() != null) { 
+						if(oldEntity.equals(newEntity) == false) {
+							stringBuilder.append(oldField.getName());
+							stringBuilder.append(": ");												
+							stringBuilder.append((Objects.isNull(oldEntity.getId()) == false ? oldEntity : "null"));
+							stringBuilder.append(unicodeRightArrow);
+							stringBuilder.append((Objects.isNull(newEntity.getId()) == false ? newEntity : "null"));
+							stringBuilder.append(fin);
+						}
+					}
+				} else if (cls.isEnum() == true) {
+					Enum<?> oldEnum = Objects.isNull(oldField.get(oldObject)) ? null : (Enum<?>) oldField.get(oldObject);
+					Enum<?> newEnum = Objects.isNull(oldField.get(newObject)) ? null : (Enum<?>) oldField.get(newObject);
+					if(Objects.isNull(oldEnum) == false || Objects.isNull(newEnum) == false) { 
+						if(oldEnum != newEnum) {
+							stringBuilder.append(oldField.getName());
+							stringBuilder.append(": ");												
+							stringBuilder.append((Objects.isNull(oldEnum) == false ? oldEnum: "null"));
+							stringBuilder.append(unicodeRightArrow);
+							stringBuilder.append((Objects.isNull(newEnum) == false ? newEnum : "null"));
+							stringBuilder.append(fin);
+						}
+					}
 				} else {
 					if (oldField.getAnnotation(DcemGui.class) != null || oldField.getName().equals(DcemConstants.USERPORTAL_PREFERNCESES_TYPE_COMPARE)) {
 						Object oldFieldValue = oldField.get(oldObject);
@@ -839,7 +943,7 @@ public class DcemUtils {
 						if (oldFieldValue == null && newFieldValue != null) {
 							stringBuilder.append(oldField.getName());
 							stringBuilder.append(": ");
-							stringBuilder.append("NULL");
+							stringBuilder.append("null");
 							stringBuilder.append(unicodeRightArrow);
 							stringBuilder.append(newFieldValue.toString());
 							stringBuilder.append(fin);
@@ -848,7 +952,7 @@ public class DcemUtils {
 							stringBuilder.append(": ");
 							stringBuilder.append(oldFieldValue.toString());
 							stringBuilder.append(unicodeRightArrow);
-							stringBuilder.append("NULL");
+							stringBuilder.append("null");
 							stringBuilder.append(fin);
 						} else {
 							if (oldFieldValue.equals(newFieldValue) == false) {
@@ -1495,9 +1599,8 @@ public class DcemUtils {
 		BufferedImage outputImage = resampler.filter(inputImage, null);
 		try {
 			ImageIO.write(outputImage, "png", outputStream);
-		} catch (Exception e) {
-			logger.error("Couldn't resize image", e);
-			
+		} catch (IOException e) {
+
 		}
 		if (outputStream.toByteArray().length > maxLenght) {
 			throw new DcemException(DcemErrorCodes.IMAGE_TOO_BIG, "wrong widht or height");

--- a/DcemSetup/.classpath
+++ b/DcemSetup/.classpath
@@ -42,7 +42,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry combineaccessrules="false" kind="src" path="/RecruitingModule"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/shiftsscheduler"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/SkillsModule"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/OAuthModule/.gitignore
+++ b/OAuthModule/.gitignore
@@ -1,2 +1,3 @@
 /bin/
 /target/
+/testbin/

--- a/RadiusModule/.gitignore
+++ b/RadiusModule/.gitignore
@@ -1,2 +1,3 @@
 /bin/
 /target/
+/testbin/

--- a/RadiusModule/src/com/doubleclue/dcem/radius/entities/RadiusClientEntity_.java
+++ b/RadiusModule/src/com/doubleclue/dcem/radius/entities/RadiusClientEntity_.java
@@ -4,7 +4,7 @@ import javax.annotation.Generated;
 import javax.persistence.metamodel.SingularAttribute;
 import javax.persistence.metamodel.StaticMetamodel;
 
-@Generated(value="Dali", date="2021-04-19T09:10:24.501+0200")
+@Generated(value="Dali", date="2023-06-12T16:00:51.470+0200")
 @StaticMetamodel(RadiusClientEntity.class)
 public class RadiusClientEntity_ {
 	public static volatile SingularAttribute<RadiusClientEntity, Integer> id;

--- a/RadiusModule/src/com/doubleclue/dcem/radius/entities/RadiusClientEntity_.java
+++ b/RadiusModule/src/com/doubleclue/dcem/radius/entities/RadiusClientEntity_.java
@@ -4,7 +4,7 @@ import javax.annotation.Generated;
 import javax.persistence.metamodel.SingularAttribute;
 import javax.persistence.metamodel.StaticMetamodel;
 
-@Generated(value="Dali", date="2023-06-12T16:00:51.470+0200")
+@Generated(value="Dali", date="2023-06-13T12:50:32.169+0200")
 @StaticMetamodel(RadiusClientEntity.class)
 public class RadiusClientEntity_ {
 	public static volatile SingularAttribute<RadiusClientEntity, Integer> id;

--- a/RadiusModule/src/com/doubleclue/dcem/radius/entities/RadiusReportEntity_.java
+++ b/RadiusModule/src/com/doubleclue/dcem/radius/entities/RadiusReportEntity_.java
@@ -6,7 +6,7 @@ import javax.annotation.Generated;
 import javax.persistence.metamodel.SingularAttribute;
 import javax.persistence.metamodel.StaticMetamodel;
 
-@Generated(value="Dali", date="2023-06-12T16:00:51.502+0200")
+@Generated(value="Dali", date="2023-06-13T12:50:32.180+0200")
 @StaticMetamodel(RadiusReportEntity.class)
 public class RadiusReportEntity_ {
 	public static volatile SingularAttribute<RadiusReportEntity, Integer> id;

--- a/RadiusModule/src/com/doubleclue/dcem/radius/entities/RadiusReportEntity_.java
+++ b/RadiusModule/src/com/doubleclue/dcem/radius/entities/RadiusReportEntity_.java
@@ -6,7 +6,7 @@ import javax.annotation.Generated;
 import javax.persistence.metamodel.SingularAttribute;
 import javax.persistence.metamodel.StaticMetamodel;
 
-@Generated(value="Dali", date="2021-02-04T13:25:39.376+0100")
+@Generated(value="Dali", date="2023-06-12T16:00:51.502+0200")
 @StaticMetamodel(RadiusReportEntity.class)
 public class RadiusReportEntity_ {
 	public static volatile SingularAttribute<RadiusReportEntity, Integer> id;


### PR DESCRIPTION
Added DcemGui ignoreCompare() 
Recreated CloudSafeEntity hashCode() with id only
Updated DcemUtils compareObject: can now compare Lists<?>, Enums, Entities extending EntityInterface, IPhoto byte arrays, and long form Strings.